### PR TITLE
MNT: add pyqt designer setup scripts

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,30 @@
+# Install the package
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+
+# Create auxiliary dirs
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+mkdir -p $PREFIX/etc/pcdswidgets
+
+# Create auxiliary vars
+DESIGNER_PLUGIN_PATH=$PREFIX/etc/pcdswidgets
+DESIGNER_PLUGIN=$DESIGNER_PLUGIN_PATH/pcdswidgets_designer_plugin.py
+ACTIVATE=$PREFIX/etc/conda/activate.d/pcdswidgets
+DEACTIVATE=$PREFIX/etc/conda/deactivate.d/pcdswidgets
+
+echo "from pcdswidgets.designer import *" >> $DESIGNER_PLUGIN
+
+echo "export PYQTDESIGNERPATH=\$CONDA_PREFIX/etc/pcdswidgets:\$PYQTDESIGNERPATH" >> $ACTIVATE.sh
+echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE.sh
+
+echo '@echo OFF' >> $ACTIVATE.bat
+echo 'IF "%PYQTDESIGNERPATH%" == "" (' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pcdswidgets' >> $ACTIVATE.bat
+echo ')ELSE (' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pcdswidgets;%PYQTDESIGNERPATH%' >> $ACTIVATE.bat
+echo ')' >> $ACTIVATE.bat
+
+unset DESIGNER_PLUGIN_PATH
+unset DESIGNER_PLUGIN
+unset ACTIVATE
+unset DEACTIVATE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,8 @@ source:
   sha256: 07f4dc9deb72ef41bbaadd9b41255d8e4b9198ba7975eec999df3d2c39524489
 
 build:
+  number: 1
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:


### PR DESCRIPTION
The build.sh script that packages like pydm and typhos use to make sure their widgets are loaded properly in qt desginer are not present in this recipe. Compare this recipe after my changes to https://github.com/conda-forge/pydm-feedstock/tree/master/recipe and https://github.com/conda-forge/typhos-feedstock/tree/master/recipe

Tested locally via conda build and installing into a local environment

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
